### PR TITLE
Specify macos-latest (CI pytest)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This changes macos-12 back to macos-latest, which is now macos-12.

See https://github.com/actions/runner-images/pull/6901.