### PR TITLE
Add conda/mamba alternative to pipenv

### DIFF
--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -1,0 +1,28 @@
+name: "pytest --doctest-modules (conda)"
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Provision with micromamba
+        uses: mamba-org/provision-with-micromamba@v15
+
+      - name: Run all tests
+        run: pytest --doctest-modules

--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -1,4 +1,4 @@
-name: "pytest --doctest-modules (conda)"
+name: pytest (conda)
 
 on: [push, pull_request]
 

--- a/.github/workflows/pytest-pipenv.yml
+++ b/.github/workflows/pytest-pipenv.yml
@@ -1,4 +1,4 @@
-name: "pytest --doctest-modules"
+name: pytest (pipenv)
 
 on: [push, pull_request]
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: algorithms-python
+
+channels:
+  - conda-forge
+ 
+dependencies:
+  - python=3.11
+  - flake8
+  - jupyterlab
+  - pylint
+  - pytest


### PR DESCRIPTION
In addition to the pipenv/pip-based way.

On CI, this uses micromamaba to make and use the conda environment.