### PR TITLE
Use multiple Python versions in CI conda test matrix

### DIFF
--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -23,7 +23,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Substitute Python version
-        run: sed -Ei 's/^( *- python=).+$/\1${{ matrix.python-version }}/' environment.yml
+        run: |
+          # We don't need a backup, but sed -i is otherwise less portable.
+          sed -E -i.old 's/^( *- python=).+$/\1${{ matrix.python-version }}/' \
+              environment.yml
 
       - name: Provision with micromamba
         uses: mamba-org/provision-with-micromamba@v15

--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Substitute Python version
-        run: |
-          sed -Ei 's/^( *- python=).+$/\1${{ matrix.python-version }}/' \
+        run: >
+          sed -Ei 's/^( *- python=).+$/\1${{ matrix.python-version }}/'
               environment.yml
 
       - name: Provision with micromamba

--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -20,6 +21,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Substitute Python version
+        run: |
+          sed -Ei 's/^( *- python=).+$/\1${{ matrix.python-version }}/' \
+              environment.yml
 
       - name: Provision with micromamba
         uses: mamba-org/provision-with-micromamba@v15

--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -23,9 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Substitute Python version
-        run: >
-          sed -Ei 's/^( *- python=).+$/\1${{ matrix.python-version }}/'
-              environment.yml
+        run: sed -Ei 's/^( *- python=).+$/\1${{ matrix.python-version }}/' environment.yml
 
       - name: Provision with micromamba
         uses: mamba-org/provision-with-micromamba@v15

--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -24,9 +24,8 @@ jobs:
 
       - name: Substitute Python version
         run: |
-          # We don't need a backup, but sed -i is otherwise less portable.
-          sed -E -i.old 's/^( *- python=).+$/\1${{ matrix.python-version }}/' \
-              environment.yml
+          perl -i -spwe 's/^( *- python=).+$/$1$pyver/' -- \
+              -pyver=${{ matrix.python-version }} environment.yml
 
       - name: Provision with micromamba
         uses: mamba-org/provision-with-micromamba@v15

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
  
 dependencies:
-  - python=3.11
+  - python=3.10
   - flake8
   - jupyterlab
   - pylint

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
  
 dependencies:
-  - python=3.9
+  - python=3.8
   - flake8
   - jupyterlab
   - pylint

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
  
 dependencies:
-  - python=3.10
+  - python=3.9
   - flake8
   - jupyterlab
   - pylint

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
  
 dependencies:
-  - python=3.8
+  - python=3.7
   - flake8
   - jupyterlab
   - pylint

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
  
 dependencies:
-  - python=3.7
+  - python=3.11
   - flake8
   - jupyterlab
   - pylint


### PR DESCRIPTION
This parameterizes by Python version as well as operating system.

It applies only to the *pytest (conda)* workflow, at least for now.

It might be worthwhile to do something like this in the *pytest (pipenv)* workflow, but not likely in any of the currently existing non-pytest workflows.