### PR TITLE
CI pytest with pipenv, multiple Python versions

### DIFF
--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Substitute Python version
         run: |
-          perl -i -spwe 's/^( *- python=).+$/$1$pyver/' -- \
+          perl -i -spwe 's/^ *- python=\K.+$/$pyver/' -- \
               -pyver=${{ matrix.python-version }} environment.yml
 
       - name: Provision with micromamba

--- a/.github/workflows/pytest-pipenv-lock.yml
+++ b/.github/workflows/pytest-pipenv-lock.yml
@@ -1,4 +1,4 @@
-name: pytest (pipenv)
+name: pytest (Pipfile.lock)
 
 on: [push, pull_request]
 

--- a/.github/workflows/pytest-pipenv.yml
+++ b/.github/workflows/pytest-pipenv.yml
@@ -1,0 +1,53 @@
+name: pytest (Pipfile)
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Remove Pipfile.lock
+        run: rm Pipfile.lock
+
+      - name: Drop full Python version
+        run: |
+          perl -i -nwe 'print unless /^python_full_version = "[^"]+"$/' Pipfile
+
+      - name: Substitute Python version
+        run: |
+          perl -i -spwe 's/(?<=^python_version = ")[^"]+(?="$)/$pyver/' -- \
+              -pyver=${{ matrix.python-version }} Pipfile
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade PyPA packages
+        run: python -m pip install -U pip setuptools wheel
+
+      - name: Install pipenv
+        run: pip install pipenv
+
+      - name: Install project with all dependencies
+        run: pipenv install -d
+
+      - name: Run all tests
+        run: pipenv run pytest --doctest-modules
+        timeout-minutes: 2

--- a/.github/workflows/pytest-pipenv.yml
+++ b/.github/workflows/pytest-pipenv.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Substitute Python version
         run: |
-          perl -i -spwe 's/(?<=^python_version = ")[^"]+(?="$)/$pyver/' -- \
+          perl -i -spwe 's/^python_version = "\K[^"]+(?="$)/$pyver/' -- \
               -pyver=${{ matrix.python-version }} Pipfile
 
       - name: Set up Python


### PR DESCRIPTION
This does not use the committed Pipfile.lock.

The older workflow, recently renamed pytest-pipenv-lock.yml, is retained, in part for the value of testing with the committed Pipfile.lock.