### PR TITLE
Let large text matrices fail fast

### DIFF
--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -7,10 +7,9 @@ jobs:
     name: Test
 
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pytest-pipenv.yml
+++ b/.github/workflows/pytest-pipenv.yml
@@ -7,10 +7,9 @@ jobs:
     name: Test
 
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This actually makes two changes:

1. Stop turning off fail-fast for the CI matrix workflows that generate more than a few jobs.

2. Reorder the python-version values to go from high-to-low rather than low-to-high. Although this order is slightly less intuitive, it puts the tests we are more interested in first.

If a change to the code causes a test to fail, then tests generated from the same matrix that have not yet begun will no longer start; that's the point of (1).

But this will tend to cause tests listed farther down not to be run. If a change to the code causes it to fail on Python 3.7, for example, is that because of a bug that would affect the versions we're more interested in? Or is it due to an unrecognized incompatibility with an old version that we are less interested in?

Since, **in this project**, the later versions of Python are more important than the earlier ones (this is not intended as a stable reusable library), the disadvantage of (1) is mitigated by (2). Tests with newer versions of Python will tend to run earlier, rather than later, so whether a bug that causes a test failure affects the versions of Python we're interested in will usually be apparent.