### PR TITLE
Have dependabot update monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20


### PR DESCRIPTION
This has dependabot scan for Python dependencies, and make PRs for them, monthly instead of weekly.

It shouldn't affect security alerts or most updates for known security vulnerabilities.