### PR TITLE
Migrate to setup-micromamba

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,8 +48,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Provision with micromamba
-      uses: mamba-org/provision-with-micromamba@v16
+    - name: Set up micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: environment.yml
 
     - name: Set interpreter
       run: |

--- a/.github/workflows/pytest-conda.yml
+++ b/.github/workflows/pytest-conda.yml
@@ -26,8 +26,10 @@ jobs:
           perl -i -spwe 's/^ *- python=\K.+$/$pyver/' -- \
               -pyver=${{ matrix.python-version }} environment.yml
 
-      - name: Provision with micromamba
-        uses: mamba-org/provision-with-micromamba@v16
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
 
       - name: Run all tests
         run: pytest --doctest-modules


### PR DESCRIPTION
Since provision-with-micromamba is now deprecated.

See:

- https://github.com/mamba-org/provision-with-micromamba/releases/tag/v16
- https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba
- https://github.com/mamba-org/setup-micromamba