### PR TITLE
Have Dependabot group Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
+    groups:
+      python-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Instead of opening all separate pull requests.

Note that this feature is still experimental, per:

- https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups