### PR TITLE
Revert "Revert "Have Dependabot group Python dependencies (#133)" (#139)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
+    groups:
+      python-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Now that the `groups` feature is considered stable, reenable it.

https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/

This reverts commit 801912d13c8fbd08703de23cab3039fe67df1137.

I'm not sure if this will immediately generate a PR without further action, since the configured cap of 20 Dependabot PRs are already open.