### PR TITLE
Revert "Revert "Revert "Have Dependabot group Python dependencies (#133)" (#139)" (#170)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
-    groups:
-      python-dependencies:
-        patterns: ['*']
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Once again, this only gets a few dependencies--jupyterlab, pylint, and pytest--when there are *numerous* dependencies to update. See #171.

This reverts commit 8e3eca56083f15f5aa8342292f504fd206367c3e.