### PR TITLE
Fix the collector job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,6 +247,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Don't skip `all-pass` on cancellation, since a skipped required check won't block auto-merge.
+    if: always()
+
     steps:
       - name: Some failed
         if: contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')


### PR DESCRIPTION
This adds the missing `if: always()` without which branch protection will allow auto-merge to proceed when dependencies are cancelled. This is the same fix as in https://github.com/EliahKagan/subaudit/pull/81.